### PR TITLE
Fix pulse cookie encoding

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -235,7 +235,7 @@ function readCookie(hexStr) {
 
 function readCookieFile(path) {
   try {
-    return readCookie(readFileSync(path, 'ascii').trim());
+    return readCookie(readFileSync(path, 'hex'));
   } catch (ex) {
     return null;
   }


### PR DESCRIPTION
After reboot paclient would connect without an issue, but if I killed pulseaudio (and let it restart), then paclient would not connect. I noticed `hex` encoding was used when working with cookies, but `ascii` was used when reading, so I switched it to `hex`. This fixed the connection issue for me.